### PR TITLE
Changed invalid import of urllib to urllib.parse

### DIFF
--- a/craftar/_common.py
+++ b/craftar/_common.py
@@ -8,7 +8,7 @@
 import json
 import re
 import requests
-from urllib import urlencode
+from urllib.parse import urlencode
 from craftar import settings
 
 HEADERS = {

--- a/craftar/_common.py
+++ b/craftar/_common.py
@@ -8,7 +8,11 @@
 import json
 import re
 import requests
-from urllib.parse import urlencode
+try:
+    from urllib import urlencode
+except ImportError:
+    # Fallback to maintain backward compatibility with Python 2
+    from urllib.parse import urlencode
 from craftar import settings
 
 HEADERS = {


### PR DESCRIPTION
urllib package structure has changed in Python 3.x, see
http://stackoverflow.com/questions/10268966/python-3-2-error-saying-urllib-parse-urlencode-is-not-defined

Resolves issue #3 (https://github.com/Catchoom/craftar-python/issues/3)